### PR TITLE
Tweaks

### DIFF
--- a/SCR_PlayerController.c
+++ b/SCR_PlayerController.c
@@ -1,6 +1,6 @@
 modded class SCR_PlayerController
 {
-	void CombineMags(MagazineComponent fromMag, MagazineComponent toMag)
+	void CombineMags(MagazineComponent fromMag, MagazineComponent toMag, SCR_InventoryStorageManagerComponent managerComp)
 	{
 		if(!fromMag || !toMag)
 		{
@@ -12,9 +12,29 @@ modded class SCR_PlayerController
 		int toCount = toMag.GetAmmoCount();
 		int maxCount = toMag.GetMaxAmmoCount();
 		
+		IEntity fromEntity = fromMag.GetOwner();
+		IEntity toEntity = toMag.GetOwner();
+		BaseInventoryStorageComponent storage = TW<BaseInventoryStorageComponent>.Find(managerComp.GetOwner());
+		
+		if(!storage)
+		{
+			Print("TrainWreck: Was unable to locate storage or manager components", LogLevel.ERROR);
+			return;
+		}
+		
 		if(fromCount + toCount <= maxCount)
 		{
 			toMag.SetAmmoCount(fromCount + toCount);
+
+			// Removing + Adding appears to make the magazine "stack" or "refresh"
+			if(managerComp.TryRemoveItemFromInventory(toEntity, storage))
+			{
+				// Just print something if for whatever reason we can't add the magazine back
+				if(!managerComp.TryInsertItemInStorage(toEntity, storage))
+				{
+					Print("TrainWreck: Was unable to successfully add packed magazine back into storage", LogLevel.ERROR);
+				}
+			}
 			
 			// From mag was fully exhausted 			
 			SCR_EntityHelper.DeleteEntityAndChildren(fromMag.GetOwner());
@@ -24,28 +44,62 @@ modded class SCR_PlayerController
 			int remainder = (fromCount + toCount) % maxCount;
 			
 			toMag.SetAmmoCount(maxCount);
+
+			// Removing + Adding appears to make the magazines "stack" or "refresh"
+			if(managerComp.TryRemoveItemFromInventory(toEntity, storage))
+			{
+				// Just print something if for whatever reason we can't add the magazine back
+				if(!managerComp.TryInsertItemInStorage(toEntity, storage))
+				{
+					Print("TrainWreck: Was unable to successfully add packed magazine back into storage", LogLevel.ERROR);
+				}
+			}
 			
 			if(remainder > 0)
+			{
 				fromMag.SetAmmoCount(remainder);
+				
+				if(managerComp.TryRemoveItemFromInventory(fromEntity, storage))
+				{
+					if(!managerComp.TryInsertItemInStorage(fromEntity, storage))
+					{
+						Print("TrainWreck: Was unable to successfully add packed magazine back into storage", LogLevel.ERROR);
+					}
+				}
+			}				
 			else 
 				SCR_EntityHelper.DeleteEntityAndChildren(fromMag.GetOwner());
 		}	
 	}	
 	
 	[RplRpc(RplChannel.Reliable, RplRcver.Server)]
-	
-	void RpcAsk_CombineMags(RplId fromMagazineComponent, RplId toMagazineComponent)
+	void RpcAsk_CombineMags(RplId fromMagazineComponent, RplId toMagazineComponent, RplId storageManagerComponent)
 	{
-		if(!fromMagazineComponent.IsValid() || 
-		   !toMagazineComponent.IsValid())
+		/*
+  		    We just need the two magazines which need tweaking, along with the storage manager.
+ 		*/
+		if(!fromMagazineComponent.IsValid())
 		{
-			Print("Invalid magazine components");
+			Print("Invalid from magazine", LogLevel.ERROR);
+			return;
+		}
+		
+		if(!toMagazineComponent.IsValid())
+		{
+			Print("Invalid to magazine", LogLevel.ERROR);
+			return;
+		}
+		
+		if(!storageManagerComponent.IsValid())
+		{
+			Print("Invalid manager", LogLevel.ERROR);
 			return;
 		}
 		
 		MagazineComponent fromMag = MagazineComponent.Cast(Replication.FindItem(fromMagazineComponent));
 		MagazineComponent toMag = MagazineComponent.Cast(Replication.FindItem(toMagazineComponent));
+		SCR_InventoryStorageManagerComponent managerComponent = SCR_InventoryStorageManagerComponent.Cast(Replication.FindItem(storageManagerComponent));
 		
-		CombineMags(fromMag, toMag);		
+		CombineMags(fromMag, toMag, managerComponent);		
 	}
 };

--- a/SCR_PlayerController.c
+++ b/SCR_PlayerController.c
@@ -18,7 +18,7 @@ modded class SCR_PlayerController
 		
 		if(!storage)
 		{
-			Print("TrainWreck: Was unable to locate storage or manager components", LogLevel.ERROR);
+			Print("Was unable to locate storage or manager components", LogLevel.ERROR);
 			return;
 		}
 		
@@ -32,7 +32,7 @@ modded class SCR_PlayerController
 				// Just print something if for whatever reason we can't add the magazine back
 				if(!managerComp.TryInsertItemInStorage(toEntity, storage))
 				{
-					Print("TrainWreck: Was unable to successfully add packed magazine back into storage", LogLevel.ERROR);
+					Print("Was unable to successfully add packed magazine back into storage", LogLevel.ERROR);
 				}
 			}
 			
@@ -51,7 +51,7 @@ modded class SCR_PlayerController
 				// Just print something if for whatever reason we can't add the magazine back
 				if(!managerComp.TryInsertItemInStorage(toEntity, storage))
 				{
-					Print("TrainWreck: Was unable to successfully add packed magazine back into storage", LogLevel.ERROR);
+					Print("Was unable to successfully add packed magazine back into storage", LogLevel.ERROR);
 				}
 			}
 			
@@ -63,7 +63,7 @@ modded class SCR_PlayerController
 				{
 					if(!managerComp.TryInsertItemInStorage(fromEntity, storage))
 					{
-						Print("TrainWreck: Was unable to successfully add packed magazine back into storage", LogLevel.ERROR);
+						Print("Was unable to successfully add packed magazine back into storage", LogLevel.ERROR);
 					}
 				}
 			}				


### PR DESCRIPTION
So, after some thought, and a bunch of testing

Was unable to reliably get the UI to refresh, or better yet - have magazines stack again without having to reopen the inventory.
To combat this, we figured... why not "remove" and "add" the magazine(s) once packed? That seemed to work! 

- RPC has been updated to require a storage manager component replication ID. This is so the server can do its thing with the mags, then remove/add as necessary. 
- So far it appears to work for stacked magazines? We did notice certain mags or belts weren't working but probably has to do with the ammo variants. For instance, standard ammo versus tracer. Makes sense, but something to watch for.
- If either mags are full - ignore packing
